### PR TITLE
improve pipeline to release merged api docs

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -51,7 +51,9 @@ jobs:
           title: "Update API documentation [${{ env.TITLE_DATETIME }}]"
           body: |
             This PR updates
-            - the OpenAPI documentation `./openapi.yaml` is copied from the gateway repositories main branch
+            - the `./openapi.yaml` is copied from the gateway repositories main branch
+            - the `./openapi.yaml` is copied from the action repositories main branch
+            - `openapi-gateway.yaml` and `openapi-action.yaml` are merged into `./openapi.yaml`
             - the redoc generated documentation is generated to `./index.html`
             - the postman collection is generated to `./ecolytiq-api.postman_collection.json`
             

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+set -euxo pipefail
+
 npx -y @redocly/cli@1.12.0 join openapi-gateway.yaml openapi-action.yaml --without-x-tag-groups -o openapi.yaml
 npx -y @redocly/cli@1.12.0 build-docs openapi.yaml  --disableGoogleFont --template ./ecolytiq.hbs --output=index.html --config=./redocly.yaml
+
+# Replace the version in the openapi.yaml file with the current date
+CURRENT_DATE=$(date +%Y-%m-%d)
+# sed differs for MacOS and Linux if you try inplace replacement i.e. we do not use -i flag
+sed "s/version: .*/version: v3-$CURRENT_DATE/" openapi.yaml > temp.yaml && mv temp.yaml openapi.yaml
+
 bash ./buildPostman.sh openapi.yaml ecolytiq_Sandbox.postman_collection.json


### PR DESCRIPTION
1. We want to use the current date as the version.
2. We want the pipeline to print all commands executed and not swallow errors.